### PR TITLE
fix NetEndian for targets with pointer width other than 64

### DIFF
--- a/src/netendian.rs
+++ b/src/netendian.rs
@@ -5,7 +5,7 @@ pub trait NetEndian {
 }
 
 impl NetEndian for usize {
-    type Bytes = [u8; 8];
+    type Bytes = [u8; (usize::BITS / 8) as usize];
     fn bytes(&self) -> Self::Bytes {
         return self.to_be_bytes();
     }
@@ -47,7 +47,7 @@ impl NetEndian for u128 {
 }
 
 impl NetEndian for isize {
-    type Bytes = [u8; 8];
+    type Bytes = [u8; (isize::BITS / 8) as usize];
     fn bytes(&self) -> Self::Bytes {
         return self.to_be_bytes();
     }


### PR DESCRIPTION
Notably this currently fails to compile on WASM32.